### PR TITLE
Add pdb in uploaded file

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -34,6 +34,7 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: |
         cp -a D:/a/BDSpyrunner/test/bdxcore_mod/*.dll D:/out
+        cp -a D:/a/BDSpyrunner/test/bdxcore_mod/*.pdb D:/out
       shell: bash
 
     - name: Upload artifact


### PR DESCRIPTION
在上传的文件中添加pdb，方便在崩服后查询错误原因
具体理由：https://www.minebbs.com/threads/bds-pdb.7169/